### PR TITLE
Make server generate PilotIds and then enable all connection methods

### DIFF
--- a/AWUnitTests/Game/GobUtils/CoronerTest.cs
+++ b/AWUnitTests/Game/GobUtils/CoronerTest.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using NUnit.Framework;
 using AW2.Game.Players;
-using AW2.Helpers;
+using AW2.TestHelpers;
 
 namespace AW2.Game.GobUtils
 {
@@ -21,10 +21,10 @@ namespace AW2.Game.GobUtils
         {
             Coroner.ResetPhraseSets();
             _avengers = new Team("Avengers", null);
-            _player1 = new Player(null, "Player 1", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
-            _player2 = new Player(null, "Player 2", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
-            _player3 = new Player(null, "Player 3", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
-            _player4 = new Player(null, "Player 4", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
+            _player1 = PlayerHelper.Make(1);
+            _player2 = PlayerHelper.Make(2);
+            _player3 = PlayerHelper.Make(3);
+            _player4 = PlayerHelper.Make(4);
             _player1.AssignTeam(_avengers);
             _player4.AssignTeam(_avengers);
             _arena = new Arena();

--- a/AWUnitTests/Game/GobUtils/DamageInfoTest.cs
+++ b/AWUnitTests/Game/GobUtils/DamageInfoTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 using AW2.Game.Players;
-using AW2.Helpers;
+using AW2.TestHelpers;
 
 namespace AW2.Game.GobUtils
 {
@@ -19,9 +19,9 @@ namespace AW2.Game.GobUtils
         {
             _arena = new Arena();
             _avengers = new Team("Avengers", null);
-            _player1 = new Player(null, "Player 1", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
-            _player2 = new Player(null, "Player 2", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
-            _player3 = new Player(null, "Player 3", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
+            _player1 = PlayerHelper.Make(1);
+            _player2 = PlayerHelper.Make(2);
+            _player3 = PlayerHelper.Make(3);
             _player2.AssignTeam(_avengers);
             _player3.AssignTeam(_avengers);
             _gob1 = new Gob { ID = 10, Owner = _player1, MaxDamageLevel = 100, Arena = _arena };

--- a/AWUnitTests/Game/GobUtils/TargetSelectorTest.cs
+++ b/AWUnitTests/Game/GobUtils/TargetSelectorTest.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Xna.Framework;
 using NUnit.Framework;
 using AW2.Game.Players;
-using AW2.Helpers;
+using AW2.TestHelpers;
 
 namespace AW2.Game.GobUtils
 {
@@ -19,8 +18,8 @@ namespace AW2.Game.GobUtils
         [SetUp]
         public void Setup()
         {
-            _player1 = new Player(null, "Player 1", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
-            _player2 = new Player(null, "Player 2", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
+            _player1 = PlayerHelper.Make(1);
+            _player2 = PlayerHelper.Make(2);
             _arena = new Arena();
             _source = new Gob { ID = 1, Owner = _player1, MaxDamageLevel = 100, Arena = _arena, Pos = Vector2.Zero };
             _hostileGob1 = new Gob { ID = 2, Owner = _player2, MaxDamageLevel = 100, Arena = _arena };

--- a/AWUnitTests/Game/Logic/GameplayModeTest.cs
+++ b/AWUnitTests/Game/Logic/GameplayModeTest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using AW2.Game.Players;
-using AW2.Helpers;
+using AW2.TestHelpers;
 
 namespace AW2.Game.Logic
 {
@@ -25,12 +25,12 @@ namespace AW2.Game.Logic
             _team2 = new Team("X-Men", null) { ID = 12 };
             _team3 = new Team("Autobots", null) { ID = 13 };
             _team4 = new Team("Decepticons", null) { ID = 14 };
-            _player1 = new Player(null, "Player 1", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls()) { ID = 1 };
-            _player2 = new Player(null, "Player 2", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls()) { ID = 2 };
-            _player3 = new Player(null, "Player 3", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls()) { ID = 3 };
-            _player4 = new Player(null, "Player 4", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls()) { ID = 4 };
-            _player5 = new Player(null, "Player 5", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls()) { ID = 5 };
-            _player6 = new Player(null, "Player 6", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls()) { ID = 6 };
+            _player1 = PlayerHelper.Make(1);
+            _player2 = PlayerHelper.Make(2);
+            _player3 = PlayerHelper.Make(3);
+            _player4 = PlayerHelper.Make(4);
+            _player5 = PlayerHelper.Make(5);
+            _player6 = PlayerHelper.Make(6);
         }
 
         [Test]

--- a/AWUnitTests/Game/Players/TeamTest.cs
+++ b/AWUnitTests/Game/Players/TeamTest.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using NUnit.Framework;
 using AW2.Game.Gobs;
 using AW2.Game.GobUtils;
 using AW2.Helpers;
+using AW2.TestHelpers;
 
 namespace AW2.Game.Players
 {
@@ -21,14 +20,14 @@ namespace AW2.Game.Players
         {
             CanonicalString.IsForLocalUseOnly = true;
             _arena = new Arena();
+            _player1 = PlayerHelper.Make(1);
+            _player2 = PlayerHelper.Make(2);
+            _player3 = PlayerHelper.Make(3);
             _ship1 = new Ship((CanonicalString)"Bugger") { Owner = _player1, MaxDamageLevel = 100, Arena = _arena };
             _ship2 = new Ship((CanonicalString)"Bugger") { Owner = _player2, MaxDamageLevel = 100, Arena = _arena };
             _ship3 = new Ship((CanonicalString)"Bugger") { Owner = _player3, MaxDamageLevel = 100, Arena = _arena };
             _avengers = new Team("Avengers", null);
             _xmen = new Team("X-Men", null);
-            _player1 = new Player(null, "Player 1", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
-            _player2 = new Player(null, "Player 2", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
-            _player3 = new Player(null, "Player 3", CanonicalString.Null, CanonicalString.Null, CanonicalString.Null, new UI.PlayerControls());
             SeizeShip(_player1, _ship1);
             SeizeShip(_player2, _ship2);
             SeizeShip(_player3, _ship3);

--- a/AWUnitTests/Helpers/SecureIdTest.cs
+++ b/AWUnitTests/Helpers/SecureIdTest.cs
@@ -44,9 +44,9 @@ namespace AW2.Helpers
                 accumulator += secureId.MakeId($"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {i}").Length;
             }
             stopWatch.Stop();
-            // This should output something much less than 1ms. Since the server is single threaded it could stutter
+            // This be somethingmuch less than 1ms. Since the server is single threaded it could stutter
             // when a player joins if the SecureId is adjusted to be too slow.
-            Console.WriteLine($"Duration of single operation {((float)stopWatch.ElapsedMilliseconds) / count} ms");
+            Assert.Less(((float)stopWatch.ElapsedMilliseconds) / count, 0.1f);
             Assert.AreEqual(count * 24, accumulator);
         }
     }

--- a/AWUnitTests/Helpers/SecureIdTest.cs
+++ b/AWUnitTests/Helpers/SecureIdTest.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+
+namespace AW2.Helpers
+{
+    [TestFixture]
+    public class SecureIdTest
+    {
+        [Test]
+        public void TestStable()
+        {
+            var secureId = new SecureId();
+            Assert.AreEqual(secureId.MakeId("foo"), secureId.MakeId("foo"));
+            Assert.AreEqual(secureId.MakeId("bar"), secureId.MakeId("bar"));
+            Assert.AreNotEqual(secureId.MakeId("foo"), secureId.MakeId("bar"));
+        }
+
+        [Test]
+        public void TestLength()
+        {
+            var secureId = new SecureId();
+            Assert.AreEqual(24, secureId.MakeId("foo").Length);
+        }
+
+        [Test]
+        public void TestSalted()
+        {
+            var secureId1 = new SecureId();
+            var secureId2 = new SecureId();
+            Assert.AreNotEqual(secureId1.MakeId("foo"), secureId2.MakeId("foo"));
+        }
+
+        [Test]
+        public void TestSpeed()
+        {
+            var secureId = new SecureId();
+            int accumulator = 0;
+            Stopwatch stopWatch = new Stopwatch();
+            stopWatch.Start();
+            var count = 10000;
+            foreach (var i in Enumerable.Range(0, count)) {
+                accumulator += secureId.MakeId($"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {i}").Length;
+            }
+            stopWatch.Stop();
+            // This should output something much less than 1ms. Since the server is single threaded it could stutter
+            // when a player joins if the SecureId is adjusted to be too slow.
+            Console.WriteLine($"Duration of single operation {((float)stopWatch.ElapsedMilliseconds) / count} ms");
+            Assert.AreEqual(count * 24, accumulator);
+        }
+    }
+}

--- a/AWUnitTests/TestHelpers/PlayerHelper.cs
+++ b/AWUnitTests/TestHelpers/PlayerHelper.cs
@@ -1,0 +1,18 @@
+using AW2.Game.Players;
+using AW2.Helpers;
+using AW2.UI;
+
+namespace AW2.TestHelpers {
+    static class PlayerHelper {
+
+        public static Player Make(int id) {
+            return new Player(game: null,
+                pilotId: "pilotId:" + id, 
+                name: $"Player {id}", 
+                shipTypeName: CanonicalString.Null, 
+                weapon2Name: CanonicalString.Null, 
+                extraDeviceName: CanonicalString.Null, 
+                controls: new PlayerControls()) {ID = id};
+        }
+    }
+}

--- a/AssaultWing/Menu/MenuEngineImpl.cs
+++ b/AssaultWing/Menu/MenuEngineImpl.cs
@@ -68,7 +68,7 @@ namespace AW2.Menu
             get
             {
                 var localPlayer = Game.DataEngine.LocalPlayer;
-                if (localPlayer == null || !localPlayer.StatsData.IsLoggedIn) return null;
+                if (localPlayer == null || !localPlayer.IsLoggedIn) return null;
                 return localPlayer;
             }
         }

--- a/AssaultWingCore/Core/AssaultWing.cs
+++ b/AssaultWingCore/Core/AssaultWing.cs
@@ -739,7 +739,8 @@ namespace AW2.Core
                     FailMessage = "",
                 };
 
-                if (spectator.PilotId == null) return false;
+                // Server always assigns the PilotId. In Steam mode it is a securely hashed steam id
+                spectator.PilotId = NetworkEngine.GetPilotId(spectator.ConnectionID);
 
                 var oldSpectator = DataEngine.Spectators.FirstOrDefault(spec => spec.PilotId == spectator.PilotId);
                 if (oldSpectator == null)

--- a/AssaultWingCore/Game/DataEngine.cs
+++ b/AssaultWingCore/Game/DataEngine.cs
@@ -179,13 +179,13 @@ namespace AW2.Game
                     operation.ExistingSpectator.AssignTeam(team);
                     break;
                 case TeamOperation.ChoiceType.CreateToExistingTeam:
-                    var botPlayer = new BotPlayer(Game) { Name = operation.NewSpectatorName };
+                    var botPlayer = new BotPlayer(Game, pilotId: "botId:" + operation.NewSpectatorName) { Name = operation.NewSpectatorName };
                     Spectators.Add(botPlayer);
                     botPlayer.AssignTeam(operation.ExistingTeam);
                     break;
                 case TeamOperation.ChoiceType.CreateToNewTeam:
                     var team2 = new Team(operation.NewTeamName, FindSpectator);
-                    var botPlayer2 = new BotPlayer(Game) { Name = operation.NewSpectatorName };
+                    var botPlayer2 = new BotPlayer(Game, pilotId: "botId:" + operation.NewSpectatorName) { Name = operation.NewSpectatorName };
                     Teams.Add(team2);
                     Spectators.Add(botPlayer2);
                     botPlayer2.AssignTeam(team2);

--- a/AssaultWingCore/Game/Players/BotPlayer.cs
+++ b/AssaultWingCore/Game/Players/BotPlayer.cs
@@ -31,8 +31,8 @@ namespace AW2.Game.Players
         public override IEnumerable<Gob> Minions { get { return _bots; } }
         private Arena Arena { get { return Game.DataEngine.Arena; } }
 
-        public BotPlayer(AssaultWingCore game, int connectionID = Spectator.CONNECTION_ID_LOCAL, string lastKnownConnectionAddressString = null)
-            : base(game, connectionID, lastKnownConnectionAddressString)
+        public BotPlayer(AssaultWingCore game, string pilotId, int connectionID = Spectator.CONNECTION_ID_LOCAL)
+            : base(game, pilotId: pilotId, connectionId: connectionID)
         {
             _bots = new List<Gob>();
         }

--- a/AssaultWingCore/Game/Players/Player.cs
+++ b/AssaultWingCore/Game/Players/Player.cs
@@ -230,9 +230,9 @@ namespace AW2.Game.Players
         /// <param name="weapon2Name">Name of the type of secondary weapon.</param>
         /// <param name="extraDeviceName">Name of the type of extra device.</param>
         /// <param name="controls">Player's in-game controls.</param>
-        public Player(AssaultWingCore game, string name, CanonicalString shipTypeName, CanonicalString weapon2Name,
+        public Player(AssaultWingCore game, string pilotId, string name, CanonicalString shipTypeName, CanonicalString weapon2Name,
             CanonicalString extraDeviceName, PlayerControls controls)
-            : this(game, name, shipTypeName, weapon2Name, extraDeviceName, controls, CONNECTION_ID_LOCAL, null)
+            : this(game, pilotId: pilotId, name: name, shipTypeName: shipTypeName, weapon2Name: weapon2Name, extraDeviceName: extraDeviceName, controls: controls, connectionId: CONNECTION_ID_LOCAL)
         {
         }
 
@@ -246,9 +246,9 @@ namespace AW2.Game.Players
         /// <param name="connectionId">Identifier of the connection to the remote game instance
         /// at which the player lives.</param>
         /// <see cref="AW2.Net.Connection.ID"/>
-        public Player(AssaultWingCore game, string name, CanonicalString shipTypeName, CanonicalString weapon2Name,
-            CanonicalString extraDeviceName, int connectionId, string lastKnownConnectionAddressString)
-            : this(game, name, shipTypeName, weapon2Name, extraDeviceName, new PlayerControls
+        public Player(AssaultWingCore game, string pilotId, string name, CanonicalString shipTypeName, CanonicalString weapon2Name,
+            CanonicalString extraDeviceName, int connectionId)
+            : this(game, pilotId: pilotId, name: name, shipTypeName: shipTypeName, weapon2Name: weapon2Name, extraDeviceName: extraDeviceName, controls: new PlayerControls
             {
                 Thrust = new RemoteControl(),
                 Left = new RemoteControl(),
@@ -256,13 +256,13 @@ namespace AW2.Game.Players
                 Fire1 = new RemoteControl(),
                 Fire2 = new RemoteControl(),
                 Extra = new RemoteControl()
-            }, connectionId, lastKnownConnectionAddressString)
+            }, connectionId: connectionId)
         {
         }
 
-        private Player(AssaultWingCore game, string name, CanonicalString shipTypeName, CanonicalString weapon2Name,
-            CanonicalString extraDeviceName, PlayerControls controls, int connectionId, string lastKnownConnectionAddressString)
-            : base(game, connectionId, lastKnownConnectionAddressString)
+        private Player(AssaultWingCore game, string pilotId, string name, CanonicalString shipTypeName, CanonicalString weapon2Name,
+            CanonicalString extraDeviceName, PlayerControls controls, int connectionId)
+            : base(game, pilotId: pilotId, connectionId: connectionId)
         {
             Name = name;
             ShipName = shipTypeName;

--- a/AssaultWingCore/Game/Players/Spectator.cs
+++ b/AssaultWingCore/Game/Players/Spectator.cs
@@ -49,6 +49,20 @@ namespace AW2.Game.Players
         /// </summary>
         public int LocalID { get; set; }
 
+        /// <summary>This is a securely hashed id meant to detect if a player
+        /// joining is the same player as in some earlier connection. In Steam
+        /// mode the hashed value is the Steam ID. In raw networking mode this
+        /// is a combination of client address and player name. secure hashing
+        /// is used to prevent identifying information of a player from leaking
+        /// to clients of other players.
+        /// </summary>
+        public string PilotId { get; set; }
+        
+        /// <summary>
+        /// This is true in Steam mode and false in raw networking mode.
+        /// </summary>
+        public bool IsLoggedIn { get; set; }
+
         /// <summary>
         /// Identifier of the connection behind which this spectator lives,
         /// or negative if the spectator lives at the local game instance.
@@ -59,11 +73,6 @@ namespace AW2.Game.Players
         /// Data received from the statistics server.
         /// </summary>
         public SpectatorStats StatsData { get; set; }
-
-        /// <summary>
-        /// The last known IP address of the connection of the spectator. For local players it's 127.0.0.1.
-        /// </summary>
-        public string LastKnownConnectionAddressString { get; private set; }
 
         /// <summary>
         /// Is the spectator connected from a remote game instance.
@@ -113,12 +122,12 @@ namespace AW2.Game.Players
 
         private ConnectionStatusType ConnectionStatus { get; set; }
 
-        public Spectator(AssaultWingCore game, int connectionId = CONNECTION_ID_LOCAL, string lastKnownConnectionAddressString = null)
+        public Spectator(AssaultWingCore game, string pilotId, int connectionId = CONNECTION_ID_LOCAL)
         {
             Game = game;
+            pilotId = pilotId;
             ConnectionID = connectionId;
             ConnectionStatus = connectionId == CONNECTION_ID_LOCAL ? ConnectionStatusType.Local : ConnectionStatusType.Remote;
-            LastKnownConnectionAddressString = lastKnownConnectionAddressString ?? IPAddress.Loopback.ToString();
             ArenaStatistics = new ArenaStatistics();
             PreviousArenaStatistics = new ArenaStatistics();
             StatsData = new SpectatorStats();

--- a/AssaultWingCore/Game/Players/Spectator.cs
+++ b/AssaultWingCore/Game/Players/Spectator.cs
@@ -125,7 +125,8 @@ namespace AW2.Game.Players
         public Spectator(AssaultWingCore game, string pilotId, int connectionId = CONNECTION_ID_LOCAL)
         {
             Game = game;
-            pilotId = pilotId;
+            Name = "<uninitialised>";
+            PilotId = pilotId;
             ConnectionID = connectionId;
             ConnectionStatus = connectionId == CONNECTION_ID_LOCAL ? ConnectionStatusType.Local : ConnectionStatusType.Remote;
             ArenaStatistics = new ArenaStatistics();
@@ -221,6 +222,10 @@ namespace AW2.Game.Players
 #endif
             checked
             {
+                if (mode.HasFlag(SerializationModeFlags.ConstantDataFromServer))
+                {
+                    writer.Write((string)PilotId);
+                }
                 if (mode.HasFlag(SerializationModeFlags.ConstantDataFromServer) ||
                     mode.HasFlag(SerializationModeFlags.ConstantDataFromClient))
                 {
@@ -237,6 +242,10 @@ namespace AW2.Game.Players
 
         public virtual void Deserialize(NetworkBinaryReader reader, SerializationModeFlags mode, int framesAgo)
         {
+            if (mode.HasFlag(SerializationModeFlags.ConstantDataFromServer))
+            {
+                PilotId = reader.ReadString();
+            }
             if (mode.HasFlag(SerializationModeFlags.ConstantDataFromServer) ||
                 mode.HasFlag(SerializationModeFlags.ConstantDataFromClient))
             {

--- a/AssaultWingCore/Helpers/SecureId.cs
+++ b/AssaultWingCore/Helpers/SecureId.cs
@@ -14,7 +14,7 @@ namespace AW2.Helpers
 
         private readonly int SaltSize = 128;
 
-        private readonly int IterationCount = 100; // Adjusted to be fast enough using the test SecureIdTest
+        private readonly int IterationCount = 10; // Adjusted to be fast enough using the test SecureIdTest
 
         private readonly int IdBytes = 16;
 

--- a/AssaultWingCore/Helpers/SecureId.cs
+++ b/AssaultWingCore/Helpers/SecureId.cs
@@ -1,0 +1,33 @@
+using System.Security.Cryptography;
+
+namespace AW2.Helpers
+{
+    /// <summary>
+    /// Use a shared salt that is regenerated for every server (and client) instance.
+    /// This is then used to generate unique IDs from values that we don't want to
+    /// share between clients. The IDs will remain stable for as long the same server process
+    /// is running, but clients can't decode each others details.
+    /// </summary>
+    public class SecureId
+    {
+        private byte[] Salt;
+
+        private readonly int SaltSize = 128;
+
+        private readonly int IterationCount = 100; // Adjusted to be fast enough using the test SecureIdTest
+
+        private readonly int IdBytes = 16;
+
+        public SecureId() {
+            Salt = RandomNumberGenerator.GetBytes(SaltSize);
+        }
+
+        public string MakeId(string input) {
+            Rfc2898DeriveBytes pbkdf2 = new Rfc2898DeriveBytes(input, Salt);
+            pbkdf2.IterationCount = IterationCount;
+            var hashedBytes = pbkdf2.GetBytes(IdBytes);
+            var id = Convert.ToBase64String(hashedBytes);
+            return id;
+        }
+    }
+} 

--- a/AssaultWingCore/Helpers/Steam.cs
+++ b/AssaultWingCore/Helpers/Steam.cs
@@ -15,5 +15,14 @@ namespace AW2.Helpers {
             return buffer;
         }
 
+        public static string IdentityToAddrPreferred(SteamNetConnectionInfo_t info) {
+            if (!info.m_addrRemote.IsIPv6AllZeros() && !info.m_addrRemote.IsFakeIP()) {
+                string buffer;
+                info.m_addrRemote.ToString(out buffer, true);
+                return buffer;
+            } else {
+                return IdentityToString(info.m_identityRemote);
+            }
+        }
     }
 }

--- a/AssaultWingCore/Net/Connections/ConnectionSteam.cs
+++ b/AssaultWingCore/Net/Connections/ConnectionSteam.cs
@@ -38,6 +38,8 @@ namespace AW2.Net.Connections
 
         public HSteamNetConnection Handle { get; init; }
         public SteamNetConnectionInfo_t Info { get; set; }
+        
+        public string SteamId => Info.m_identityRemote.GetSteamID().ToString();
 
         // Implemented by subclass because server and client use separate Steam interfaces to allow for dedicated
         // server to operate without proper Steam user.

--- a/AssaultWingCore/Net/Connections/GameServerConnectionSteam.cs
+++ b/AssaultWingCore/Net/Connections/GameServerConnectionSteam.cs
@@ -17,7 +17,7 @@ namespace AW2.Net.Connections
         public GameServerConnectionSteam(AssaultWingCore game, HSteamNetConnection handle, SteamNetConnectionInfo_t info)
             : base(game, handle, info)
         {
-            Name = $"Game Server {Steam.IdentityToString(info.m_identityRemote)}";
+            Name = $"Game Server {Steam.IdentityToAddrPreferred(info)}";
         }
 
         protected override void DisposeImpl(bool error)

--- a/AssaultWingCore/Net/GameServerInfo.cs
+++ b/AssaultWingCore/Net/GameServerInfo.cs
@@ -59,9 +59,12 @@ namespace AW2.Net
 
         public AWEndPoint[] GameServerEndPoints {
             get {
-                // TODO: Peter: Allow attempting multiple connections. Now 1 failing kills the rest.
-                // SteamNetworkingIpEndpoint, SteamIdEndpoint
-                return new AWEndPoint[]{DirectIpEndpoint};
+                // Returning 3 end points to attempt both direct
+                // (DirectIpEndpoint) and the Steam Datagram Relay based
+                // connection (SteamIdEndpoint). Does the middle one
+                // (SteamNetworkingIpEndpoint) bring any value here or always
+                // just extra load?
+                return new AWEndPoint[]{DirectIpEndpoint, SteamNetworkingIpEndpoint, SteamIdEndpoint};
             }
         }
 

--- a/AssaultWingCore/Net/MessageHandling/MessageHandlers.cs
+++ b/AssaultWingCore/Net/MessageHandling/MessageHandlers.cs
@@ -315,13 +315,12 @@ namespace AW2.Net.MessageHandling
 
         private Spectator GetSpectator(SpectatorSettingsRequest mess, SerializationModeFlags mode)
         {
-            string pilotId = Game.NetworkEngine.GetPilotId(mess.ConnectionID);
             Spectator newSpectator;
             switch (mess.Subclass)
             {
                 case SpectatorSettingsRequest.SubclassType.Player:
                     newSpectator = new Player(Game, 
-                        pilotId: pilotId,
+                        pilotId: "<uninitialised pilotId>",
                         name: "<uninitialised>", 
                         shipTypeName: CanonicalString.Null, 
                         weapon2Name: CanonicalString.Null,
@@ -329,7 +328,7 @@ namespace AW2.Net.MessageHandling
                         connectionId: mess.ConnectionID);
                     break;
                 case SpectatorSettingsRequest.SubclassType.BotPlayer:
-                    newSpectator = new BotPlayer(Game, pilotId: pilotId, connectionID: mess.ConnectionID);
+                    newSpectator = new BotPlayer(Game, pilotId: "<uninitialised bot pilotId>", connectionID: mess.ConnectionID);
                     break;
                 default: throw new ApplicationException("Unexpected spectator subclass " + mess.Subclass);
             }

--- a/AssaultWingCore/Net/MessageHandling/MessageHandlers.cs
+++ b/AssaultWingCore/Net/MessageHandling/MessageHandlers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -315,16 +315,21 @@ namespace AW2.Net.MessageHandling
 
         private Spectator GetSpectator(SpectatorSettingsRequest mess, SerializationModeFlags mode)
         {
-            var lastKnownConnectionAddressString = Game.NetworkEngine.GetConnectionAddressString(mess.ConnectionID);
+            string pilotId = Game.NetworkEngine.GetPilotId(mess.ConnectionID);
             Spectator newSpectator;
             switch (mess.Subclass)
             {
                 case SpectatorSettingsRequest.SubclassType.Player:
-                    newSpectator = new Player(Game, "<uninitialised>", CanonicalString.Null, CanonicalString.Null,
-                        CanonicalString.Null, mess.ConnectionID, lastKnownConnectionAddressString = lastKnownConnectionAddressString);
+                    newSpectator = new Player(Game, 
+                        pilotId: pilotId,
+                        name: "<uninitialised>", 
+                        shipTypeName: CanonicalString.Null, 
+                        weapon2Name: CanonicalString.Null,
+                        extraDeviceName: CanonicalString.Null, 
+                        connectionId: mess.ConnectionID);
                     break;
                 case SpectatorSettingsRequest.SubclassType.BotPlayer:
-                    newSpectator = new BotPlayer(Game, mess.ConnectionID, lastKnownConnectionAddressString = lastKnownConnectionAddressString);
+                    newSpectator = new BotPlayer(Game, pilotId: pilotId, connectionID: mess.ConnectionID);
                     break;
                 default: throw new ApplicationException("Unexpected spectator subclass " + mess.Subclass);
             }

--- a/AssaultWingCore/Net/NetworkEngine.cs
+++ b/AssaultWingCore/Net/NetworkEngine.cs
@@ -285,5 +285,6 @@ namespace AW2.Net
             conn.ConnectionStatus.CurrentArenaName = null;
         }
 
+        public abstract  string GetPilotId(int connectionID);
     }
 }

--- a/AssaultWingCore/Net/NetworkEngineRaw.cs
+++ b/AssaultWingCore/Net/NetworkEngineRaw.cs
@@ -46,6 +46,7 @@ namespace AW2.Net
 
         #region Fields
 
+        private SecureId secureId = new SecureId();
         private const int UDP_CONNECTION_PORT_FIRST = 'A' * 256 + 'W';
         private const int UDP_CONNECTION_PORT_LAST = UDP_CONNECTION_PORT_FIRST + 9;
         private const string NETWORK_TRACE_FILE = "AWnetwork.log";
@@ -493,6 +494,12 @@ namespace AW2.Net
             _GameClientConnections.RemoveAll(c => c.IsDisposed);
         }
 
+        override public string GetPilotId(int connectionId) {
+            var connectionAddressString = GetConnectionAddressString(connectionId);
+            var id = secureId.MakeId(connectionAddressString);
+            Log.Write($"connectionAddressString: {connectionAddressString} hashed to {id}");
+            return id;
+        }
 
         #endregion Private methods
     }

--- a/AssaultWingCore/Net/NetworkEngineSteam.cs
+++ b/AssaultWingCore/Net/NetworkEngineSteam.cs
@@ -99,7 +99,7 @@ namespace AW2.Net
         {
             var result = AllConnections.First(conn => conn.ID == connectionID);
             if (result == null) return $"Unknown connection {connectionID}";
-            return Steam.IdentityToString(result.Info.m_identityRemote); // TODO: Not sure if this is best thing to print here
+            return Steam.IdentityToAddrPreferred(result.Info);
         }
 
         override public GameClientConnectionSteam GetGameClientConnection(int connectionID)

--- a/AssaultWingCore/Net/NetworkEngineSteam.cs
+++ b/AssaultWingCore/Net/NetworkEngineSteam.cs
@@ -3,7 +3,6 @@ using AW2.Helpers;
 using AW2.Net.Connections;
 using AW2.Net.Messages;
 using Steamworks;
-
 namespace AW2.Net
 {
     /// <summary>
@@ -30,6 +29,7 @@ namespace AW2.Net
     /// <seealso cref="Message.ConnectionID"/>
     public class NetworkEngineSteam : NetworkEngine
     {
+        private SecureId secureId = new SecureId();
         private List<GameClientConnectionSteam> _GameClientConnections = new List<GameClientConnectionSteam>();
         private Func<bool> AllowNewServerConnection;
 
@@ -88,7 +88,7 @@ namespace AW2.Net
             return InstanceKey.ToByteArray();
         }
 
-        public override Connection GetConnection(int connectionID)
+        public override ConnectionSteam GetConnection(int connectionID)
         {
             var result = AllConnections.First(conn => conn.ID == connectionID);
             if (result == null) throw new ArgumentException("Connection not found with ID " + connectionID);
@@ -353,5 +353,13 @@ namespace AW2.Net
             RemoveClosedConnections();
             PurgeUnhandledMessages();
         }
+        override public string GetPilotId(int connectionId) {
+            var connection = GetConnection(connectionId);
+            var steamId = connection.SteamId;
+            var id = secureId.MakeId(steamId);
+            Log.Write($"steamId: {steamId} hashed to {id}");
+            return id;
+        }
+
     }
 }

--- a/AssaultWingCore/Net/SpectatorStats.cs
+++ b/AssaultWingCore/Net/SpectatorStats.cs
@@ -1,23 +1,13 @@
-﻿using System;
-using Newtonsoft.Json.Linq;
-using AW2.Helpers.Serialization;
-using AW2.Game.Players;
-
+﻿
 namespace AW2.Net
 {
     /// <summary>
-    /// Wrapper around JSON objects received from the stats server for a spectator.
+    /// The SpectatorStats class has currently no functionality. Maybe it will
+    /// be used later when statistics are collected using Steam features.
     /// </summary>
     public class SpectatorStats
     {
-        public string PilotId { get; set; }
-        // TODO: Peter: SteamId based logged in mode with Steam, except in Raw mode
-        public bool IsLoggedIn { get; set; }
         public float Rating { get; set; }
         public int RatingRank { get; set; }
-
-        public SpectatorStats()
-        {
-        }
     }
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,9 +2,7 @@
 
 This is a rough list of things to do for the near term development:
 
-- Test joining across 2 firewalls or nats
-  - If not working, system to try multiple connection methods
-    - Fix player clones bug
+- Fix the client getting confused when server disconnects immediately upon joining (eg PilotId check)
 - Introduce version numbers
 - All steam builds
 - Change the DisableContentBuilding to just be a platform check


### PR DESCRIPTION
Move PlayerID & IsLogged in to Spectator and make the server assign
the PlayerIds.

These were in SpectatorStats previously because they were related to
the management server and stats collection.

The PlayerId is now a securely hashed SteamID when in Steam mode
and a securely hashed connection address string when in the raw
networking mode.

Secure hashing is used to make sure identifying information about
players does not unnecessarily leak to other clients.

Now the server assigns the PilotId uniquely which prevents the "cloning" bug
that I observed when testing during past few days.

## Enable multiple connection methods to get around firewalls

However, this is the main point of this PR: _Enable connecting to all 3 possible server endpoints_

This allows both getting direct connections as well as bypassing
firewall / NAT on server side.

The cloning bug seemed to happen with multiple connection methods enabled,
but it I'm not sure it was impossible with just 1 method.

However the new handling of PilotId prevents the bug.

Now another bug is more visible (again probably existed before too) that in some
cases the client goes into weird state when the server kicks the joining player out
(bc. he appears to be already connected).

Also, it seems that it is possible to be kicked out a while after quickly disconnecting and
joining but this is most likely simply because the server takes a bit of time to notice
that the client connection has died. This situation resolves quickly by simply trying again
and probably is in practice very rare.