### PR TITLE
Track global player rating+ranking using a Steam Leaderboard and the MultiElo algorithm

### DIFF
--- a/AWUnitTests/Game/Stats/MultiEloTest.cs
+++ b/AWUnitTests/Game/Stats/MultiEloTest.cs
@@ -1,0 +1,142 @@
+using System.Linq;
+using NUnit.Framework;
+
+namespace AW2.Stats
+{
+    [TestFixture]
+    public class MultiEloTest
+    {
+        private readonly double Delta = 0.0001;
+
+        [Test]
+        public void TestExpectedScore()
+        {
+            var multiElo = new MultiElo(k: 32, d: 400, logBase: 10);
+            Assert.AreEqual(0.99009, multiElo.ExpectedScore(-800), Delta);
+            Assert.AreEqual(0.90909, multiElo.ExpectedScore(-400), Delta);
+            Assert.AreEqual(0.75974, multiElo.ExpectedScore(-200), Delta);
+            Assert.AreEqual(0.64006, multiElo.ExpectedScore(-100), Delta);
+            Assert.AreEqual(0.5, multiElo.ExpectedScore(0), Delta);
+            Assert.AreEqual(0.49856, multiElo.ExpectedScore(1), Delta);
+            Assert.AreEqual(0.49712, multiElo.ExpectedScore(2), Delta);
+            Assert.AreEqual(0.35993, multiElo.ExpectedScore(100), Delta);
+            Assert.AreEqual(0.24025, multiElo.ExpectedScore(200), Delta);
+            Assert.AreEqual(0.09090, multiElo.ExpectedScore(400), Delta);
+            Assert.AreEqual(0.00990, multiElo.ExpectedScore(800), Delta);
+
+            var multiEloD1 = new MultiElo(k: 32, d: 1, logBase: 10);
+            Assert.AreEqual(0.99999, multiEloD1.ExpectedScore(-10), Delta);
+            Assert.AreEqual(0.90909, multiEloD1.ExpectedScore(-1), Delta);
+            Assert.AreEqual(0.5, multiEloD1.ExpectedScore(0), Delta);
+            Assert.AreEqual(0.24025, multiEloD1.ExpectedScore(0.5f), Delta);
+            Assert.AreEqual(0.09090, multiEloD1.ExpectedScore(1), Delta);
+            Assert.AreEqual(0.00990, multiEloD1.ExpectedScore(2), Delta);
+            Assert.AreEqual(0, multiEloD1.ExpectedScore(10), Delta);
+        }
+
+        [Test]
+        public void TestExpectedScores()
+        {
+            var multiElo = new MultiElo(k: 32, d: 400, logBase: 10);
+
+            // Both players have same rating, but first one completely dominates
+            var inputRatings = new[]
+            {
+                new EloRating<string>() { PlayerId = "A", Rating = 1000, Score = 100 },
+                new EloRating<string>() { PlayerId = "B", Rating = 1000, Score = 0 },
+            };
+
+            var expectedScores = multiElo.ExpectedScores(inputRatings);
+
+            Assert.That(expectedScores, Is.EqualTo(new[] { 0.5, 0.5 }).Within(Delta));
+        }
+
+
+        [Test]
+        public void TestExpectedScores3()
+        {
+            var multiElo = new MultiElo(k: 32, d: 400, logBase: 10);
+
+            // Both players have same rating, but first one completely dominates
+            var inputRatings = new[]
+            {
+                new EloRating<string>() { PlayerId = "A", Rating = 1200, Score = 0 },
+                new EloRating<string>() { PlayerId = "B", Rating = 1000, Score = 0 },
+                new EloRating<string>() { PlayerId = "C", Rating = 900, Score = 0 },
+            };
+
+            var expectedScores = multiElo.ExpectedScores(inputRatings);
+
+            Assert.That(expectedScores, Is.EqualTo(new[] { 0.5362, 0.2934, 0.1703 }).Within(Delta));
+        }
+
+        [Test]
+        public void TestEvenRatingsTotalWin()
+        {
+            var multiElo = new MultiElo(k: 32, d: 400, logBase: 10);
+
+            // Both players have same rating, but first one completely dominates
+            var inputRatings = new[]
+            {
+                new EloRating<string>() { PlayerId = "A", Rating = 1000, Score = 100 },
+                new EloRating<string>() { PlayerId = "B", Rating = 1000, Score = 0 },
+            };
+
+            var updated = multiElo.Update(inputRatings);
+
+            Assert.AreEqual(updated.Select(r => r.Rating), new[] { 1016, 984 });
+        }
+
+        [Test]
+        public void Test3Player()
+        {
+            var multiElo = new MultiElo(k: 32, d: 400, logBase: 10);
+
+            // Both players have same rating, but first one completely dominates
+            var inputRatings = new[]
+            {
+                new EloRating<string>() { PlayerId = "A", Rating = 1200, Score = 6666 },
+                new EloRating<string>() { PlayerId = "B", Rating = 1000, Score = 3333 },
+                new EloRating<string>() { PlayerId = "B", Rating = 900, Score = 0 },
+            };
+
+            var updated = multiElo.Update(inputRatings);
+
+            Assert.AreEqual(updated.Select(r => r.Rating), new[] { 1208, 1003, 889 });
+        }
+
+        [Test]
+        public void TestEvenRatingsTie()
+        {
+            var multiElo = new MultiElo(k: 32, d: 400, logBase: 1);
+
+            // Both players have same rating and same score
+            var inputRatings = new[]
+            {
+                new EloRating<string>() { PlayerId = "A", Rating = 1000, Score = 100 },
+                new EloRating<string>() { PlayerId = "B", Rating = 1000, Score = 100 },
+            };
+
+            var updated = multiElo.Update(inputRatings);
+
+            Assert.AreEqual(updated.Select(r => r.Rating), new[] { 1000, 1000 });
+        }
+
+        [Test]
+        public void TestEvenRatingsWin()
+        {
+            var multiElo = new MultiElo(k: 32, d: 400, logBase: 10);
+
+            // Both players have same rating and same score
+            var inputRatings = new[]
+            {
+                new EloRating<string>() { PlayerId = "A", Rating = 1000, Score = 50 },
+                new EloRating<string>() { PlayerId = "B", Rating = 1000, Score = 100 },
+            };
+
+            var updated = multiElo.Update(inputRatings);
+
+            Assert.AreEqual(updated.Select(r => r.Rating), new[] { 995, 1005 });
+        }
+    }
+}

--- a/AWUnitTests/Game/Stats/MultiEloTest.cs
+++ b/AWUnitTests/Game/Stats/MultiEloTest.cs
@@ -88,6 +88,23 @@ namespace AW2.Stats
         }
 
         [Test]
+        public void TestZeroRatingsNoNegativeResult()
+        {
+            var multiElo = new MultiElo(k: 32, d: 400, logBase: 10);
+
+            // Both players have same rating, but first one completely dominates
+            var inputRatings = new[]
+            {
+                new EloRating<string>() { PlayerId = "A", Rating = 0, Score = 100 },
+                new EloRating<string>() { PlayerId = "B", Rating = 0, Score = 0 },
+            };
+
+            var updated = multiElo.Update(inputRatings);
+
+            Assert.AreEqual(updated.Select(r => r.Rating), new[] { 16, 0 });
+        }
+
+        [Test]
         public void Test3Player()
         {
             var multiElo = new MultiElo(k: 32, d: 400, logBase: 10);

--- a/AssaultWing/UI/UserControlledLogic.cs
+++ b/AssaultWing/UI/UserControlledLogic.cs
@@ -7,6 +7,7 @@ using AW2.Core.GameComponents;
 using AW2.Core.OverlayComponents;
 using AW2.Helpers;
 using AW2.Menu;
+using AW2.Stats;
 
 namespace AW2.UI
 {
@@ -56,6 +57,14 @@ namespace AW2.UI
             Game.Components.Add(PlayerChat);
             Game.Components.Add(OverlayDialog);
             Game.Components.Add(SteamServerComponent);
+
+            if (game.IsSteam)
+            {
+                var ratingUploader = new PilotRatingUploader(game);
+                Game.Components.Add(ratingUploader);
+                ratingUploader.Enabled = true;
+            }
+
             CreateCustomControls(Game);
             Game.MessageHandlers.GameServerConnectionClosing += Handle_GameServerConnectionClosing;
         }

--- a/AssaultWingCore/Core/AssaultWing.cs
+++ b/AssaultWingCore/Core/AssaultWing.cs
@@ -18,6 +18,8 @@ using AW2.Net.Messages;
 using AW2.UI;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework;
+using Steamworks;
+using AW2.Stats;
 
 namespace AW2.Core
 {
@@ -67,6 +69,7 @@ namespace AW2.Core
             {
                 Log.Write("AssaultWing is in Steam mode");
                 NetworkEngine = new NetworkEngineSteam(this, 30);
+                Services.AddService(new SteamLeaderboardService(Services.GetService<SteamApiService>()));
             }
             else
             {

--- a/AssaultWingCore/Core/SteamApiService.cs
+++ b/AssaultWingCore/Core/SteamApiService.cs
@@ -3,7 +3,6 @@ using Steamworks;
 
 namespace AW2.Core
 {
-
     public class SteamApiService : IDisposable
     {
         // TODO: Move the callback stuff to a separate service bc it is shared with SteamGameServerService
@@ -116,6 +115,11 @@ namespace AW2.Core
         {
             ServerCallback<DebugLoggingBundle, SteamNetConnectionStatusChangedCallback_t>(LogSteamNetConnectionStatusChanged);
             ServerCallback<DebugLoggingBundle, SteamRelayNetworkStatus_t>(LogSteamRelayNetworkStatus);
+        }
+
+        public CSteamID SteamID
+        {
+            get { return SteamUser.GetSteamID(); }
         }
 
         public string UserNick

--- a/AssaultWingCore/Game/Logic/Standings.cs
+++ b/AssaultWingCore/Game/Logic/Standings.cs
@@ -17,6 +17,8 @@ namespace AW2.Game.Logic
         public Standing this[Team team] { get { return GetTeamStandings(team).Item1; } }
         public Standing this[Spectator spec] { get { return GetTeamStandings(spec.Team).Item2.First(x => x.ID == spec.ID); } }
 
+        public Standing? FindForSpectator(Spectator spec) { return GetTeamStandings(spec.Team).Item2.FirstOrDefault(x => x.ID == spec.ID); }
+
         public Standings(TeamStandings[] standings)
         {
             _standings = standings;

--- a/AssaultWingCore/Game/Players/Player.cs
+++ b/AssaultWingCore/Game/Players/Player.cs
@@ -10,6 +10,8 @@ using AW2.Graphics.OverlayComponents;
 using AW2.Helpers;
 using AW2.Helpers.Serialization;
 using AW2.UI;
+using Steamworks;
+using AW2.Stats;
 
 namespace AW2.Game.Players
 {
@@ -19,6 +21,12 @@ namespace AW2.Game.Players
     [System.Diagnostics.DebuggerDisplay("ID:{ID} Name:{Name} ShipName:{ShipName}")]
     public class Player : Spectator
     {
+
+        /// <summary>
+        /// Ranking and score in the Steam leaderboards.
+        /// </summary>
+        internal PilotRanking Ranking { get; set; }
+
         /// <summary>
         /// Time between death of player's ship and birth of a new ship,
         /// measured in seconds.
@@ -351,6 +359,13 @@ namespace AW2.Game.Players
                         writer.Write((CanonicalString)Weapon2Name);
                         writer.Write((CanonicalString)ExtraDeviceName);
                     }
+                    // Server determines the ranks and scores of players.
+                    if (mode.HasFlag(SerializationModeFlags.ConstantDataFromServer))
+                    {
+                        writer.Write(Ranking.Rating);
+                        writer.Write(Ranking.Rank);
+                        writer.Write(Ranking.RatingAwardedTime.Ticks);
+                    }
                 }
             }
         }
@@ -367,6 +382,16 @@ namespace AW2.Game.Players
                 if (Game.DataEngine.GetTypeTemplate(newShipName) is Ship) ShipName = newShipName;
                 if (Game.DataEngine.GetTypeTemplate(newWeapon2Name) is Weapon) Weapon2Name = newWeapon2Name;
                 if (Game.DataEngine.GetTypeTemplate(newExtraDeviceName) is ShipDevice) ExtraDeviceName = newExtraDeviceName;
+            }
+            // Server determines the ranks and scores of players.
+            if (mode.HasFlag(SerializationModeFlags.ConstantDataFromServer))
+            {
+                Ranking = new PilotRanking()
+                {
+                    Rank = reader.ReadInt32(),
+                    Rating = reader.ReadInt32(),
+                    RatingAwardedTime = new DateTime(reader.ReadInt64())
+                };
             }
         }
 

--- a/AssaultWingCore/Helpers/Serialization/SerializationModeFlags.cs
+++ b/AssaultWingCore/Helpers/Serialization/SerializationModeFlags.cs
@@ -34,6 +34,11 @@ namespace AW2.Helpers.Serialization
         VaryingDataFromClient = 0x08,
 
         /// <summary>
+        /// For local client, don't overwrite data as the local client is considered the owner of the data.
+        /// </summary>
+        KeepLocalClientOwnedData = 0x10,
+
+        /// <summary>
         /// Serialise all data from server to client.
         /// </summary>
         AllFromServer = ConstantDataFromServer | VaryingDataFromServer,

--- a/AssaultWingCore/Net/Connections/ConnectionSteam.cs
+++ b/AssaultWingCore/Net/Connections/ConnectionSteam.cs
@@ -39,7 +39,7 @@ namespace AW2.Net.Connections
         public HSteamNetConnection Handle { get; init; }
         public SteamNetConnectionInfo_t Info { get; set; }
 
-        public string SteamId => Info.m_identityRemote.GetSteamID().ToString();
+        public CSteamID SteamId => Info.m_identityRemote.GetSteamID();
 
         // Implemented by subclass because server and client use separate Steam interfaces to allow for dedicated
         // server to operate without proper Steam user.

--- a/AssaultWingCore/Net/NetworkEngine.cs
+++ b/AssaultWingCore/Net/NetworkEngine.cs
@@ -5,6 +5,7 @@ using AW2.Net.Messages;
 using AW2.Helpers;
 using AW2.Net.ConnectionUtils;
 using AW2.Game;
+using Steamworks;
 
 namespace AW2.Net
 {
@@ -190,6 +191,11 @@ namespace AW2.Net
         public abstract string GetConnectionAddressString(int connectionID);
 
         protected abstract IEnumerable<ConnectionBase> AllConnections { get; }
+
+        /// <summary>
+        /// Returns null if the game is in non steam mode. Typically used with Specattor.ConnectionID.
+        /// </summary>
+        public abstract CSteamID? GetSteamId(int connectionID);
 
         /// <summary>
         /// Returns the number of frames elapsed since the message was sent.

--- a/AssaultWingCore/Net/NetworkEngineRaw.cs
+++ b/AssaultWingCore/Net/NetworkEngineRaw.cs
@@ -7,6 +7,7 @@ using AW2.Net.Connections;
 using AW2.Net.ConnectionUtils;
 using AW2.Net.MessageHandling;
 using AW2.Net.Messages;
+using Steamworks;
 
 namespace AW2.Net
 {
@@ -198,6 +199,8 @@ namespace AW2.Net
         {
             return _GameClientConnections.First(conn => conn.ID == connectionID);
         }
+
+        override public CSteamID? GetSteamId(int connectionId) => null;
 
         override public ConnectionRaw GetConnection(int connectionID)
         {

--- a/AssaultWingCore/Net/NetworkEngineSteam.cs
+++ b/AssaultWingCore/Net/NetworkEngineSteam.cs
@@ -111,6 +111,8 @@ namespace AW2.Net
             return _GameClientConnections.First(conn => conn.ID == connectionID);
         }
 
+        override public CSteamID? GetSteamId(int connectionId) => AllConnections.First(conn => conn.ID == connectionId)?.SteamId;
+
         public GameClientConnectionSteam? GetGameClientConnectionByHandle(HSteamNetConnection handle)
         {
             return _GameClientConnections.FirstOrDefault(conn => conn.Handle == handle);
@@ -440,7 +442,7 @@ namespace AW2.Net
         {
             var connection = GetConnection(connectionId);
             var steamId = connection.SteamId;
-            var id = secureId.MakeId(steamId);
+            var id = secureId.MakeId(steamId.ToString());
             Log.Write($"steamId: {steamId} hashed to {id}");
             return id;
         }

--- a/AssaultWingCore/Net/NetworkEngineSteam.cs
+++ b/AssaultWingCore/Net/NetworkEngineSteam.cs
@@ -111,7 +111,48 @@ namespace AW2.Net
             return _GameClientConnections.First(conn => conn.ID == connectionID);
         }
 
-        override public CSteamID? GetSteamId(int connectionId) => AllConnections.First(conn => conn.ID == connectionId)?.SteamId;
+#if ALLOW_MULTIPLE_CLIENTS_PER_HOST
+        private Dictionary<int, CSteamID> ConnectionIdToAssignedSteamId = new Dictionary<int, CSteamID>();
+        private uint FakeSteamIdCounter = 1;
+#endif
+
+        override public CSteamID? GetSteamId(int connectionId)
+        {
+            var steamId = AllConnections.FirstOrDefault(conn => conn.ID == connectionId)?.SteamId;
+
+#if ALLOW_MULTIPLE_CLIENTS_PER_HOST
+            if (steamId is not null)
+            {
+                if (ConnectionIdToAssignedSteamId.ContainsKey(connectionId))
+                {
+                    return ConnectionIdToAssignedSteamId[connectionId];
+                }
+                else
+                {
+                    var originalConnection = ConnectionIdToAssignedSteamId
+                        .Where(kvp => kvp.Value == steamId).ToList();
+
+                    if (originalConnection.Count == 0)
+                    {
+                        // Create entry for the first connection with this CSteamID.
+                        ConnectionIdToAssignedSteamId[connectionId] = steamId.Value;
+                    }
+                    else
+                    {
+                        // Assign a fake CSteamID to produce a different PilotId
+                        // for this connection. to allow testing Steam features
+                        // by connecting multiple clients using the same steam
+                        // profile.
+                        steamId = new CSteamID(new AccountID_t(FakeSteamIdCounter++), EUniverse.k_EUniverseInvalid, EAccountType.k_EAccountTypeInvalid);
+                        Log.Write($"Using fake steamId {steamId} for connection {connectionId} to allow testing.");
+                        ConnectionIdToAssignedSteamId[connectionId] = steamId.Value;
+                    }
+                }
+            }
+#endif
+
+            return steamId;
+        }
 
         public GameClientConnectionSteam? GetGameClientConnectionByHandle(HSteamNetConnection handle)
         {
@@ -438,13 +479,21 @@ namespace AW2.Net
             RemoveClosedConnections();
             PurgeUnhandledMessages();
         }
+
         override public string GetPilotId(int connectionId)
         {
-            var connection = GetConnection(connectionId);
-            var steamId = connection.SteamId;
-            var id = secureId.MakeId(steamId.ToString());
-            Log.Write($"steamId: {steamId} hashed to {id}");
-            return id;
+            CSteamID? steamId = GetSteamId(connectionId);
+
+            if (steamId is null)
+            {
+                throw new NullReferenceException("Steam mode connection, but no steam id found!");
+            }
+            else
+            {
+                var id = secureId.MakeId(steamId.Value.ToString());
+                Log.Write($"steamId: {steamId} hashed to {id}");
+                return id;
+            }
         }
 
     }

--- a/AssaultWingCore/Stats/LeaderboardEntryAndUgc.cs
+++ b/AssaultWingCore/Stats/LeaderboardEntryAndUgc.cs
@@ -1,0 +1,13 @@
+using Steamworks;
+
+namespace AW2.Stats
+{
+    /// <summary>
+    /// Just the Steam base leaderboard entry and the "user generated data" UGC in one struct.
+    /// </summary>
+    public struct LeaderboardEntryAndUgc
+    {
+        public LeaderboardEntry_t entry;
+        public int[] ugc;
+    }
+}

--- a/AssaultWingCore/Stats/MultiElo.cs
+++ b/AssaultWingCore/Stats/MultiElo.cs
@@ -1,0 +1,113 @@
+
+namespace AW2.Stats
+{
+    /// Implemented based on this article
+    /// https://towardsdatascience.com/developing-a-generalized-elo-rating-system-for-multiplayer-games-b9b495e87802
+    public class MultiElo
+    {
+        readonly float K;
+        readonly float D;
+        readonly float LogBase;
+
+        /// <param name="k">The parameter of how much ratings are updated.
+        /// Typically for example 32.</param>
+        ///
+        /// <param name="d">The parameter controlling how difference in ratings
+        /// translates to expected winning probabilities. Typically for example
+        /// 400. Larger values translate the rating more weakly to probability
+        /// of winning. Affects the method <c>ExpectedScores</c>.</param>
+        ///
+        /// <param name="logBase">The parameter controlling the exponential
+        /// distribution of the "expected scores". Often used value is 10.
+        /// Affects the method <c>ExpectedScore</c>.</param>
+        public MultiElo(float k, float d, float logBase)
+        {
+            K = k;
+            D = d;
+            LogBase = logBase;
+        }
+
+        public EloRating<ID>[] Update<ID>(EloRating<ID>[] ratings)
+        {
+            int n = ratings.Count();
+            EloRating<ID>[] results = new EloRating<ID>[n];
+            var expectedScores = ExpectedScores(ratings);
+
+            double scoreSum = 0;
+            for (int i = 0; i < n; i++)
+            {
+                if (ratings[i].Score > 0) // treat negative scores as 0
+                {
+                    scoreSum += ratings[i].Score;
+                }
+            }
+
+            for (int i = 0; i < n; i++)
+            {
+                var prevRating = ratings[i];
+
+                double normalizedScore = 0;
+
+                if (prevRating.Score > 0 && scoreSum > 0) // treat negative scores as 0
+                {
+                    normalizedScore = (prevRating.Score) / scoreSum;
+                }
+
+                double updatedRatingValue = prevRating.Rating;
+                if (scoreSum > 0) // If the sum is zero, don't update ratings
+                {
+                    updatedRatingValue = prevRating.Rating + K * (n - 1) * (normalizedScore - expectedScores[i]);
+                }
+
+                results[i] = new EloRating<ID>
+                {
+                    PlayerId = prevRating.PlayerId,
+                    Score = 0,
+                    Rating = (int)Math.Round(updatedRatingValue)
+                };
+            }
+
+            return results;
+        }
+
+        public double ExpectedScore(float scoreDiff)
+        {
+            return 1.0 / (1.0 + Math.Pow(LogBase, scoreDiff / D));
+        }
+
+        public double[] ExpectedScores<ID>(EloRating<ID>[] ratings)
+        {
+            int n = ratings.Count();
+            double normalization = n * (n - 1) / 2;
+            var result = new double[n];
+            for (int i = 0; i < n; i++)
+            {
+                double sum = 0;
+                for (int j = 0; j < n; j++)
+                {
+                    if (i != j)
+                    {
+                        var diff = ratings[j].Rating - ratings[i].Rating;
+                        var score = ExpectedScore(diff);
+                        sum += score;
+                    }
+                }
+                result[i] = sum / normalization;
+            }
+
+            return result;
+        }
+    }
+
+    public struct EloRating<ID>
+    {
+        /// External ID for the player
+        public readonly ID PlayerId { get; init; }
+        /// The (Multi) Elo Rating of this player. Either previous value or
+        /// updated according to MatchPosition.
+        public readonly int Rating { get; init; }
+        /// The score of this player for the previous round. The scores are
+        /// internally normalized so that they sum to one. Tied scores are OK.
+        public readonly int Score { get; init; }
+    }
+}

--- a/AssaultWingCore/Stats/MultiElo.cs
+++ b/AssaultWingCore/Stats/MultiElo.cs
@@ -62,7 +62,7 @@ namespace AW2.Stats
                 results[i] = new EloRating<ID>
                 {
                     PlayerId = prevRating.PlayerId,
-                    Score = 0,
+                    Score = prevRating.Score,
                     // Don't output negative ratings
                     Rating = (int)Math.Max(0.0, Math.Round(updatedRatingValue))
                 };

--- a/AssaultWingCore/Stats/MultiElo.cs
+++ b/AssaultWingCore/Stats/MultiElo.cs
@@ -63,7 +63,8 @@ namespace AW2.Stats
                 {
                     PlayerId = prevRating.PlayerId,
                     Score = 0,
-                    Rating = (int)Math.Round(updatedRatingValue)
+                    // Don't output negative ratings
+                    Rating = (int)Math.Max(0.0, Math.Round(updatedRatingValue))
                 };
             }
 

--- a/AssaultWingCore/Stats/PilotRatingUploader.cs
+++ b/AssaultWingCore/Stats/PilotRatingUploader.cs
@@ -1,0 +1,54 @@
+using AW2.Core;
+using AW2.Helpers;
+
+namespace AW2.Stats
+{
+
+    /// <summary>
+    /// Runs on client and check to see if local player's PilotRanking needs to be uploaded to steam leaderboard
+    /// </summary>
+    public class PilotRatingUploader : AWGameComponent
+    {
+
+        private SteamLeaderboardService SteamLeaderboardService => Game.Services.GetService<SteamLeaderboardService>();
+
+        /// <summary>
+        /// Used on client to check if the local client's ranking needs to be uploaded to Steam now.
+        /// </summary>
+        private PilotRanking LocalClientLastUploadedRanking;
+
+        public PilotRatingUploader(AssaultWingCore game) : base(game, 100)
+        {
+        }
+
+        /// <summary>
+        /// Checks if local player has been awarded a new rating and if so, uploads it to the Steam leaderboard.
+        /// </summary>
+        override public void Update()
+        {
+            var localPlayer = Game.DataEngine.LocalPlayer;
+
+            if (localPlayer is null)
+            {
+                return; // Player does not exist while we are in the start menu.
+            }
+
+            var localRanking = localPlayer.Ranking;
+
+            if (localRanking.IsValid &&
+               localRanking.RatingAwardedTime > LocalClientLastUploadedRanking.RatingAwardedTime)
+            {
+                // If the upload fails, don't retry. Next round will try again.
+                LocalClientLastUploadedRanking = localRanking;
+                if (SteamLeaderboardService.UploadCurrentPilotRanking(localRanking))
+                {
+                    Log.Write($"PilotRatingUploader: Uploading ranking {localRanking}");
+                }
+                else
+                {
+                    Log.Write($"PilotRatingUploader: Rating upload not possible. {localRanking}");
+                }
+            }
+        }
+    }
+}

--- a/AssaultWingCore/Stats/PilotRatingsUpdater.cs
+++ b/AssaultWingCore/Stats/PilotRatingsUpdater.cs
@@ -1,0 +1,246 @@
+using System.Globalization;
+using AW2.Core;
+using AW2.Game.Logic;
+using AW2.Game.Players;
+using Steamworks;
+using AW2.Helpers;
+
+namespace AW2.Stats
+{
+    /// <summary>
+    /// Runs on the server and updates the PilotRanking of each player in the arena.
+    /// </summary>
+    public class PilotRatingsUpdater : AWGameComponent
+    {
+
+        /// <summary>
+        /// Initialize a multi elo rating system with rather standard parameters.
+        /// </summary>
+        private static readonly MultiElo multiElo = new MultiElo(k: 32, d: 400, logBase: 10);
+
+        private SteamLeaderboardService SteamLeaderboardService => Game.Services.GetService<SteamLeaderboardService>();
+
+        /// <summary>
+        /// Used on server to keep track of which players have had their ranking downloaded.
+        /// </summary>
+        private HashSet<CSteamID> RatingFetchStarted = new HashSet<CSteamID>();
+        private List<CSteamID> RatingFetchOngoing = new List<CSteamID>();
+        private HashSet<CSteamID> RatingFetchFinished = new HashSet<CSteamID>();
+        private HashSet<CSteamID> BlockRatingUpdateForPlayers = new HashSet<CSteamID>();
+
+        public PilotRatingsUpdater(AssaultWingCore game) : base(game, 100)
+        {
+        }
+
+
+        private CSteamID? GetSteamId(Player player) => Game.NetworkEngine.GetSteamId(player.ConnectionID);
+
+        /// <summary>
+        /// At the start of each round server initiates the fetching of fresh ranking information from the Steam for
+        /// the players connected at that time.
+        /// </summary>
+        public void StartArena()
+        {
+            List<CSteamID> steamIds = Game.DataEngine.Players.Select(GetSteamId).OfType<CSteamID>().ToList();
+
+            RatingFetchStarted.Clear();
+            RatingFetchOngoing.Clear();
+            RatingFetchFinished.Clear();
+            BlockRatingUpdateForPlayers.Clear();
+
+            SteamLeaderboardService.GetRankings(steamIds, HandlePilotRankings);
+        }
+
+        /// <summary>
+        /// Handle new players joining the game during the arena.
+        /// </summary>
+        override public void Update()
+        {
+            if (!SteamLeaderboardService.IsGettingRankings)
+            {
+                // Only 1 call allowed in progress at a time.
+
+                // Players who have joined since the start of the round.
+                List<CSteamID> steamIds =
+                    Game.DataEngine.Players
+                    .Select(GetSteamId)
+                    .OfType<CSteamID>()
+                    .Where(id => !RatingFetchStarted.Contains(id)).ToList();
+
+                if (steamIds.Count == 0) return;
+
+                RatingFetchOngoing = steamIds;
+
+                foreach (var steamId in steamIds)
+                {
+                    RatingFetchStarted.Add(steamId); // Only try to fetch once per arena per player.
+                }
+
+                Log.Write($"Downloading ranking information for {steamIds.Count} new players.");
+                SteamLeaderboardService.GetRankings(steamIds, HandlePilotRankings);
+            }
+        }
+
+        /// <summary>
+        /// At end of round on the server, compute new rating scores. These will
+        /// then be sent to clients which will upload the new rating to Steam
+        /// leaderboard and thus possibly get an updated rank from the leaderboard.
+        /// </summary>
+        public void EndArena(Standings standings)
+        {
+            if (!Game.DataEngine.GameplayMode.AllVsAll)
+            {
+                Log.Write("Not updating pilot ratings because game mode is not all-vs-all.");
+                // TODO: Support team aware rating algorithm? This algorithm was once considered https://www.microsoft.com/en-us/research/project/trueskill-ranking-system/
+                return;
+            }
+
+            if (Game.Settings.Players.BotsEnabled)
+            {
+                Log.Write("Not updating pilot ratings because bots are enabled.");
+                return;
+            }
+
+            List<Player> players = Game.DataEngine.Players.ToList();
+
+            if (players.Count < 2)
+            {
+                Log.Write($"Not updating pilot ratings due to player count being {players.Count}.");
+                return;
+            }
+
+            var now = DateTime.UtcNow;
+
+            var ratingInputs = players
+                .Select(p => GetEloRatingInput(p, standings))
+                .OfType<EloRating<CSteamID>>().ToArray();
+
+            if (ratingInputs.Length < 2)
+            {
+                Log.Write($"Not updating pilot ratings due to not enough players with valid state.");
+                return;
+            }
+
+            Dictionary<CSteamID, EloRating<CSteamID>> updatedRatings =
+                multiElo
+                .Update<CSteamID>(ratingInputs)
+                .ToDictionary(r => r.PlayerId);
+
+            List<String> updateLogMessages = new List<String>();
+
+            foreach (var player in players)
+            {
+                var steamId = GetSteamId(player);
+                if (steamId is not null)
+                {
+                    if (updatedRatings.ContainsKey(steamId.Value) && !BlockRatingUpdateForPlayers.Contains(steamId.Value))
+                    {
+                        var updatedRating = updatedRatings[steamId.Value];
+                        var prevRanking = player.Ranking;
+                        player.Ranking = player.Ranking.UpdateRating(updatedRating.Rating, now);
+                        updateLogMessages.Add($"[{player.Name}: {prevRanking.Rating} -> {player.Ranking.Rating}, score: {updatedRating.Score}, old awarded: {prevRanking.RatingAwardedTime.ToString("s", DateTimeFormatInfo.InvariantInfo)}]");
+                    }
+                }
+            }
+
+            Log.Write($"Updated {updateLogMessages.Count} pilot ratings: {String.Join(", ", updateLogMessages)}");
+        }
+
+        private EloRating<CSteamID>? GetEloRatingInput(Player player, Standings standings)
+        {
+            var standing = standings.FindForSpectator(player);
+
+            CSteamID? steamId = GetSteamId(player);
+            if (steamId is null)
+            {
+                Log.Write("Player {player.Name} has no Steam ID. Not updating ratings.");
+                // Returning null from this function causes the rating work as if this player didn't exist.
+                // Also the rating of this player will not be updated.
+                return null;
+            }
+            if (standing is null)
+            {
+                Log.Write("Player {player.Name} has no standing information. Not updating ratings.");
+                return null;
+            }
+
+            var currentRanking = player.Ranking;
+
+            int currentRating = 0;
+
+            if (currentRanking.IsValid)
+            {
+                currentRating = currentRanking.Rating;
+            }
+            else
+            {
+                if (RatingFetchFinished.Contains(steamId.Value))
+                {
+                    // Fresh players start with 1000 rating. 
+                    currentRating = 1000;
+                    Log.Write($"Player {player.Name} has no valid rating/ranking information. Starting with rating of 1000.");
+                }
+                else
+                {
+                    // In case of failure to download rating we can update others rating assuming this 
+                    // player has 0 rating, but we shouldn't update this players rating.
+                    Log.Write($"Player {player.Name} has no valid previously known rating and no rating information downloaded. Assuming rating 0 and not updating rating for this player.");
+                    currentRating = 0;
+                    BlockRatingUpdateForPlayers.Add(steamId.Value);
+                }
+            }
+
+            return new EloRating<CSteamID>() { PlayerId = steamId.Value, Rating = currentRating, Score = standing.Score };
+        }
+
+        private void HandlePilotRankings(Dictionary<CSteamID, PilotRanking> rankings, bool errors)
+        {
+            // Fresh players won't have a rating.
+            Log.Write($"Received {rankings.Count} pilot rankings from Steam leaderboard. Requested {RatingFetchOngoing.Count}.");
+
+            foreach (var ranking in rankings)
+            {
+                var steamId = ranking.Key;
+                var pilotRanking = ranking.Value;
+                var player = Game.DataEngine.Players.FirstOrDefault(p => GetSteamId(p) == steamId);
+                if (player is not null && pilotRanking.IsValid)
+                {
+                    // If the update of new rankings to steam is lagging, the server may have newer data than
+                    // what can be downloaded from Steam. In that case, don't overwrite the server data.
+                    // However note, that the AwardedTime can be the same, but the rank may be updated.
+                    if (player.Ranking.RatingAwardedTime < pilotRanking.RatingAwardedTime)
+                    {
+                        player.Ranking = pilotRanking;
+                        Log.Write($"Pilot {player.Name} received updated rating and ranking information {player.Ranking}");
+                    }
+                    else if (player.Ranking.RatingAwardedTime == pilotRanking.RatingAwardedTime && pilotRanking.Rank != player.Ranking.Rank)
+                    {
+                        Log.Write($"Pilot {player.Name} has the latest rating, but rank is updated {player.Ranking.Rank} -> {pilotRanking.Rank}");
+                        player.Ranking = pilotRanking;
+                    }
+                    else
+                    {
+                        Log.Write($"Pilot {player.Name} ranking information is already up to date");
+                    }
+                }
+                else
+                {
+                    Log.Write($"Pilot {player?.Name}, failed to apply received ranking information {pilotRanking}");
+                }
+            }
+
+            foreach (var steamId in RatingFetchOngoing)
+            {
+                RatingFetchFinished.Add(steamId);
+            }
+
+            if (errors)
+            {
+                Log.Write($"Errors occured while fetching pilot rankings for {RatingFetchOngoing.Count} players. As a safety precaution, their ratings won't be updated.");
+                BlockRatingUpdateForPlayers.UnionWith(RatingFetchOngoing);
+            }
+
+            RatingFetchOngoing.Clear();
+        }
+    }
+}

--- a/AssaultWingCore/Stats/SteamLeaderboardService.cs
+++ b/AssaultWingCore/Stats/SteamLeaderboardService.cs
@@ -1,0 +1,175 @@
+using Steamworks;
+using AW2.Helpers;
+using AW2.Core;
+
+namespace AW2.Stats
+{
+    /// Game server API does not seem to have leaderboards:
+    /// https://partner.steamgames.com/doc/api/ISteamGameServerStats
+    ///
+    /// https://partner.steamgames.com/doc/api/ISteamUserStats#LeaderboardFindResult_t
+    /// https://steamworks.github.io/gettingstarted/#steam-callresults
+    public class SteamLeaderboardService : IDisposable
+    {
+        public delegate void LeaderboardResultDelegate(LeaderboardEntryAndUgc[] entries, bool errors);
+
+        public delegate void RankingsResultDelegate(Dictionary<CSteamID, PilotRanking> entries, bool errors);
+
+        private static readonly SteamLeaderboard_t EmptyLeaderboard;
+        private SteamApiService SteamApiService;
+        private SteamLeaderboard_t PilotRankingLeaderboard;
+
+        private CallResult<LeaderboardFindResult_t>? FindLeaderBoardCallResult;
+
+        private CallResult<LeaderboardScoresDownloaded_t>? DownloadLeaderboardEntriesCallResult;
+        private CallResult<LeaderboardScoreUploaded_t>? LeaderboardUpdateResult;
+
+        private LeaderboardResultDelegate? DownloadLeaderboardEntriesResultDelegate;
+
+        public SteamLeaderboardService(SteamApiService steamApiService)
+        {
+            SteamApiService = steamApiService;
+            if (SteamApiService.Initialized)
+            {
+                Initialize();
+            }
+        }
+
+        private static readonly String RankingLeaderboardName = "pilot_ranking";
+
+        private void Initialize()
+        {
+            FindLeaderBoardCallResult = CallResult<LeaderboardFindResult_t>.Create(LeaderBoardFindResult);
+            var steamApiCall = SteamUserStats.FindLeaderboard(RankingLeaderboardName);
+            FindLeaderBoardCallResult.Set(steamApiCall);
+        }
+
+        private void LeaderBoardFindResult(LeaderboardFindResult_t param, bool ioFailure)
+        {
+            if (param.m_bLeaderboardFound == 0 || ioFailure)
+            {
+                Log.Write($"Failed to find Steam Leaderboard {RankingLeaderboardName} found:{param.m_bLeaderboardFound} ioFailure:{ioFailure}");
+            }
+            else
+            {
+                Log.Write($"Found Steam Leaderboard {RankingLeaderboardName}");
+                PilotRankingLeaderboard = param.m_hSteamLeaderboard;
+            }
+        }
+
+        private void LeaderBoardScoreUploaded(LeaderboardScoreUploaded_t downloaded, bool ioFailure)
+        {
+            if (ioFailure)
+            {
+                Log.Write($"Failed to upload score to Steam Leaderboard {RankingLeaderboardName} ioFailure:{ioFailure}");
+            }
+            else
+            {
+                Log.Write($"Uploaded score to Steam Leaderboard {RankingLeaderboardName}");
+            }
+
+            LeaderboardUpdateResult?.Dispose();
+            LeaderboardUpdateResult = null;
+        }
+
+        private const int MaxLeaderboardDetails = 2; // currently timestamp is stored in the extra data
+
+        private void DownloadedLeaderBoardEntriesResult(LeaderboardScoresDownloaded_t downloaded, bool ioFailure)
+        {
+            LeaderboardEntryAndUgc[] leaderboardEntries = new LeaderboardEntryAndUgc[downloaded.m_cEntryCount];
+            int[] ugcForOneEntry = new int[MaxLeaderboardDetails];
+            for (int index = 0; index < downloaded.m_cEntryCount; index++)
+            {
+                LeaderboardEntry_t entry;
+                SteamUserStats.GetDownloadedLeaderboardEntry(downloaded.m_hSteamLeaderboardEntries, index, out entry, ugcForOneEntry, MaxLeaderboardDetails);
+                leaderboardEntries[index].entry = entry;
+                leaderboardEntries[index].ugc = ugcForOneEntry;
+            }
+
+            if (DownloadLeaderboardEntriesResultDelegate != null)
+            {
+                DownloadLeaderboardEntriesResultDelegate(leaderboardEntries, errors: ioFailure);
+                DownloadLeaderboardEntriesResultDelegate = null;
+            }
+
+            DownloadLeaderboardEntriesCallResult?.Dispose();
+            DownloadLeaderboardEntriesCallResult = null;
+        }
+
+        public void GetRankings(List<CSteamID> steamIds, RankingsResultDelegate resultDelegate)
+        {
+            if (PilotRankingLeaderboard != EmptyLeaderboard)
+            {
+                DownloadLeaderboard(PilotRankingLeaderboard, steamIds, (entries, errors) =>
+                {
+                    var rankingsDictionary = new Dictionary<CSteamID, PilotRanking>(
+                        entries
+                        .Select(entry => new KeyValuePair<CSteamID, PilotRanking>(
+                            entry.entry.m_steamIDUser, PilotRanking.FromLeaderboardEntry(entry))));
+
+                    resultDelegate(rankingsDictionary, errors: errors);
+                });
+            }
+        }
+
+        public void DownloadLeaderboard(SteamLeaderboard_t leaderboard, List<CSteamID> steamIds, LeaderboardResultDelegate resultDelegate)
+        {
+            var call = SteamUserStats.DownloadLeaderboardEntriesForUsers(
+                leaderboard,
+                steamIds.ToArray(),
+                steamIds.Count
+            );
+
+            DownloadLeaderboardEntriesResultDelegate = resultDelegate;
+            DownloadLeaderboardEntriesCallResult = new CallResult<LeaderboardScoresDownloaded_t>(DownloadedLeaderBoardEntriesResult);
+            DownloadLeaderboardEntriesCallResult?.Set(call, DownloadedLeaderBoardEntriesResult);
+        }
+
+        public bool IsGettingRankings
+        {
+            get
+            {
+                return DownloadLeaderboardEntriesResultDelegate != null;
+            }
+        }
+
+        // https://partner.steamgames.com/doc/api/ISteamUserStats#UploadLeaderboardScore
+        // https://partner.steamgames.com/doc/features/leaderboards/guide
+        // Each client must upload their own score. 
+        // This needs to be coordinated with the server assuming the server computes the scores at the end
+        // of the round for all players.
+        // Maybe later we will implemented the trusted
+        // version of the leaderboard so only verified servers can upload scores.
+        // There is a rate limit of 10 updates per 10 minutes.
+        public void UploadCurrentPilotRanking(PilotRanking ranking)
+        {
+            if (PilotRankingLeaderboard != EmptyLeaderboard && LeaderboardUpdateResult is null)
+            {
+                var extraData = ranking.SteamLeaderboardUGC;
+                var result = SteamUserStats.UploadLeaderboardScore(
+                    PilotRankingLeaderboard,
+                    // Force update because the scores can also decrease according to Elo ranking.
+                    ELeaderboardUploadScoreMethod.k_ELeaderboardUploadScoreMethodForceUpdate,
+                    ranking.Rating,
+                    extraData.ToArray(),
+                    extraData.Count
+                );
+                LeaderboardUpdateResult = CallResult<LeaderboardScoreUploaded_t>.Create(LeaderBoardScoreUploaded);
+                LeaderboardUpdateResult.Set(result);
+            }
+        }
+
+        public void Dispose()
+        {
+            FindLeaderBoardCallResult?.Dispose();
+            FindLeaderBoardCallResult = null;
+            DownloadLeaderboardEntriesResultDelegate = null;
+
+            LeaderboardUpdateResult?.Dispose();
+            LeaderboardUpdateResult = null;
+
+            DownloadLeaderboardEntriesCallResult?.Dispose();
+            DownloadLeaderboardEntriesCallResult = null;
+        }
+    }
+}

--- a/AssaultWingCore/Stats/SteamLeaderboardService.cs
+++ b/AssaultWingCore/Stats/SteamLeaderboardService.cs
@@ -141,7 +141,7 @@ namespace AW2.Stats
         // Maybe later we will implemented the trusted
         // version of the leaderboard so only verified servers can upload scores.
         // There is a rate limit of 10 updates per 10 minutes.
-        public void UploadCurrentPilotRanking(PilotRanking ranking)
+        public bool UploadCurrentPilotRanking(PilotRanking ranking)
         {
             if (PilotRankingLeaderboard != EmptyLeaderboard && LeaderboardUpdateResult is null)
             {
@@ -156,6 +156,11 @@ namespace AW2.Stats
                 );
                 LeaderboardUpdateResult = CallResult<LeaderboardScoreUploaded_t>.Create(LeaderBoardScoreUploaded);
                 LeaderboardUpdateResult.Set(result);
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
- Add MultiElo algorithm and a test for it
- Add some support for the Steam leaderboards API
- Add component PilotRatingsUpdater to server side to compute ratings
- Transfer ratings to clients
- Add component on client PilotRatingUploader that uploads player's own rating to the leaderboard

To be done in upcoming PRs: visualize the player ratings and ranks in the main menu. Possibly show them also in the round ending score screen.