### PR TITLE
PlayerSettings: BotsEnabled default to false

### DIFF
--- a/AssaultWingCore/Settings/PlayerSettings.cs
+++ b/AssaultWingCore/Settings/PlayerSettings.cs
@@ -54,7 +54,7 @@ namespace AW2.Settings
         {
             Player1 = PLAYER1DEFAULT;
             Player2 = PLAYER2DEFAULT;
-            BotsEnabled = true;
+            BotsEnabled = false; // Bots disabled by default to support Steam ranking with default settings
             BotsPassword = "";
             TeamRebalancingInterval = TimeSpan.FromSeconds(15);
             DefaultPlayerName = Player1.Name;


### PR DESCRIPTION
Bots confuse old players. Maybe later run 2 servers with other having bots.