### PR TITLE
Don't crash when rendering unsupported characters

### DIFF
--- a/AssaultWingCore/Graphics/Content/AWContentManager.cs
+++ b/AssaultWingCore/Graphics/Content/AWContentManager.cs
@@ -53,6 +53,13 @@ namespace AW2.Graphics.Content
                 item = ReadAsset<T>(assetFullName, null);
                 _loadedContent.Add(assetName, item);
             }
+
+            if (typeof(T) == typeof(SpriteFont))
+            {
+                // For some reason setting this in the spritefont files didn't work.
+                ((SpriteFont)item).DefaultCharacter = '?';
+            }
+
             return (T)item;
         }
 


### PR DESCRIPTION
Of course would be better to simply support all unicode charcters...

But at least this way the came won't crash if some steam user has some symbol in his nick name.