### PR TITLE
Full Distributed Query / Update for the Ranking Leaderboard

### DIFF
--- a/AWUnitTests/Game/Stats/PilotRankingTest.cs
+++ b/AWUnitTests/Game/Stats/PilotRankingTest.cs
@@ -1,0 +1,64 @@
+using NUnit.Framework;
+using System;
+
+namespace AW2.Stats
+{
+    [TestFixture]
+    public class PilotRankingTest
+    {
+        private readonly PilotRanking NotInitialized = new PilotRanking() { State = PilotRanking.StateType.NotInitialized };
+
+        private readonly PilotRanking DownloadFailed = new PilotRanking() { State = PilotRanking.StateType.DownloadFailed };
+
+        private readonly PilotRanking NotRatedYet = new PilotRanking() { State = PilotRanking.StateType.NotRatedYet };
+
+        private readonly PilotRanking FirstTimeRated = new PilotRanking()
+        {
+            State = PilotRanking.StateType.RatingCalculated,
+            Rating = 456,
+            RatingAwardedTime = DateTime.Parse("2023-12-01T00:00:00Z")
+        };
+
+        private readonly PilotRanking Downloaded = new PilotRanking()
+        {
+            State = PilotRanking.StateType.RankingDownloaded,
+            Rating = 123,
+            RatingAwardedTime = DateTime.Parse("2023-12-02T00:00:00Z"),
+            Rank = 3,
+            RankDownloadedTime = DateTime.Parse("2023-12-03T00:00:00Z")
+        };
+
+        private readonly PilotRanking RatedAgain = new PilotRanking()
+        {
+            State = PilotRanking.StateType.RankingDownloaded,
+            Rating = 456,
+            RatingAwardedTime = DateTime.Parse("2023-12-03T00:00:00Z"),
+            Rank = 3,
+            RankDownloadedTime = DateTime.Parse("2023-12-03T00:00:00Z"),
+        };
+
+        [Test]
+        public void TestMerge()
+        {
+            Assert.AreEqual(NotInitialized, NotInitialized.Merge(NotInitialized));
+
+            Assert.AreEqual(DownloadFailed, DownloadFailed.Merge(NotInitialized));
+
+            Assert.AreEqual(Downloaded, NotInitialized.Merge(Downloaded));
+
+            Assert.AreEqual(Downloaded, Downloaded.Merge(DownloadFailed));
+
+            Assert.AreEqual(Downloaded, NotRatedYet.Merge(Downloaded));
+
+            Assert.AreEqual(FirstTimeRated, FirstTimeRated.Merge(NotRatedYet));
+
+            Assert.AreEqual(FirstTimeRated, NotRatedYet.Merge(FirstTimeRated));
+
+            Assert.AreEqual(RatedAgain, RatedAgain.Merge(FirstTimeRated));
+
+            Assert.AreEqual(RatedAgain, FirstTimeRated.Merge(RatedAgain));
+
+            Assert.AreEqual(RatedAgain, Downloaded.Merge(RatedAgain));
+        }
+    }
+}

--- a/AssaultWing/Menu/MenuEngineImpl.cs
+++ b/AssaultWing/Menu/MenuEngineImpl.cs
@@ -359,7 +359,7 @@ namespace AW2.Menu
                 return;
             }
 
-            var ranking = Game.Components.OfType<LocalPilotRankingHandler>()?.First()?.LocalPilotRanking ?? new PilotRanking();
+            var ranking = Game.Components.OfType<LocalPilotRankingHandler>()?.FirstOrDefault()?.LocalPilotRanking ?? new PilotRanking();
 
             var playerRank = ranking.RankString;
 

--- a/AssaultWing/Menu/MenuEngineImpl.cs
+++ b/AssaultWing/Menu/MenuEngineImpl.cs
@@ -363,7 +363,7 @@ namespace AW2.Menu
 
             var playerRank = ranking.RankString;
 
-            var playerRating = string.Format(CultureInfo.InvariantCulture, "rating {0}", ranking.Rating.ToString());
+            var playerRating = $"rating {ranking.RatingString}";
 
             var backgroundPos = new Vector2(ViewportWidth - _loggedInPilot.Width + 4, -_loggedInPilot.Height * (1 - GetLoggedInPlayerAnimationMultiplier()));
 

--- a/AssaultWingCore/Game/Players/Player.cs
+++ b/AssaultWingCore/Game/Players/Player.cs
@@ -10,7 +10,6 @@ using AW2.Graphics.OverlayComponents;
 using AW2.Helpers;
 using AW2.Helpers.Serialization;
 using AW2.UI;
-using Steamworks;
 using AW2.Stats;
 
 namespace AW2.Game.Players
@@ -353,14 +352,6 @@ namespace AW2.Game.Players
                         writer.Write((CanonicalString)Weapon2Name);
                         writer.Write((CanonicalString)ExtraDeviceName);
                     }
-                    // Server determines the ranks and scores of players.
-                    if (mode.HasFlag(SerializationModeFlags.ConstantDataFromServer) ||
-                        mode.HasFlag(SerializationModeFlags.VaryingDataFromServer))
-                    {
-                        writer.Write((int)Ranking.Rating);
-                        writer.Write((int)Ranking.Rank);
-                        writer.Write((long)Ranking.RatingAwardedTime.Ticks);
-                    }
                 }
             }
         }
@@ -380,20 +371,6 @@ namespace AW2.Game.Players
                     if (Game.DataEngine.GetTypeTemplate(newWeapon2Name) is Weapon) Weapon2Name = newWeapon2Name;
                     if (Game.DataEngine.GetTypeTemplate(newExtraDeviceName) is ShipDevice) ExtraDeviceName = newExtraDeviceName;
                 }
-            }
-            // Server determines the ranks and scores of players.
-            if (mode.HasFlag(SerializationModeFlags.ConstantDataFromServer) ||
-                mode.HasFlag(SerializationModeFlags.VaryingDataFromServer))
-            {
-                var rating = reader.ReadInt32();
-                var rank = reader.ReadInt32();
-                var awardedTime = new DateTime(reader.ReadInt64());
-                Ranking = new PilotRanking()
-                {
-                    Rank = rank,
-                    Rating = rating,
-                    RatingAwardedTime = awardedTime
-                };
             }
         }
 

--- a/AssaultWingCore/Net/Messages/PilotRankingMessage.cs
+++ b/AssaultWingCore/Net/Messages/PilotRankingMessage.cs
@@ -1,0 +1,58 @@
+using AW2.Game;
+using AW2.Helpers;
+using AW2.Helpers.Serialization;
+using AW2.Stats;
+
+namespace AW2.Net.Messages
+{
+    /// <summary>
+    /// A network message used to sync PilotRanking in between the clients and the server.
+    /// </summary>
+    [MessageType(0x2c, false)]
+    public class PilotRankingMessage : GameplayMessage
+    {
+        /// <summary>
+        /// A player identifier to whom this PilotRanking update is meant to.
+        /// </summary>
+        public int PlayerID { get; set; }
+        public PilotRanking PilotRanking;
+
+        protected override void SerializeBody(NetworkBinaryWriter writer)
+        {
+#if NETWORK_PROFILING
+            using (new NetworkProfilingScope(this))
+#endif
+            {
+                base.SerializeBody(writer);
+                checked
+                {
+                    writer.Write((short)PlayerID);
+                    writer.Write((byte)PilotRanking.State);
+                    writer.Write((int)PilotRanking.Rank);
+                    writer.Write((long)PilotRanking.RankDownloadedTime.Ticks);
+                    writer.Write((int)PilotRanking.Rating);
+                    writer.Write((long)PilotRanking.RatingAwardedTime.Ticks);
+                }
+            }
+        }
+
+        protected override void Deserialize(NetworkBinaryReader reader)
+        {
+            base.Deserialize(reader);
+            PlayerID = reader.ReadInt16();
+            PilotRanking = new PilotRanking()
+            {
+                State = (PilotRanking.StateType)reader.ReadByte(),
+                Rank = reader.ReadInt32(),
+                RankDownloadedTime = new DateTime(reader.ReadInt64()),
+                Rating = reader.ReadInt32(),
+                RatingAwardedTime = new DateTime(reader.ReadInt64())
+            };
+        }
+
+        public override string ToString()
+        {
+            return base.ToString() + " [" + PlayerID + ", " + PilotRanking + "]";
+        }
+    }
+}

--- a/AssaultWingCore/Stats/PilotRanking.cs
+++ b/AssaultWingCore/Stats/PilotRanking.cs
@@ -6,21 +6,63 @@ namespace AW2.Stats
 {
     public struct PilotRanking : IEquatable<PilotRanking>
     {
+
+        public enum StateType
+        {
+            /// <summary>
+            /// Not initialized yet. This is the default value.
+            /// </summary>
+            NotInitialized,
+            /// <summary>
+            /// Rating and rank was attempted to be fetched from Steam, but there was
+            /// some error and therefore the rating should not be updated for this player
+            /// and default rating value should be assumed for current round.
+            /// </summary>
+            DownloadFailed,
+            /// <summary>
+            /// Rating was attempted to be downloaded, but there was no rating
+            /// for this player. Therefore next rating calculated will be the
+            /// first one for this player.
+            /// </summary>
+            NotRatedYet,
+            /// <summary>
+            /// This rating is downloaded from Steam.
+            /// <summary>
+            RankingDownloaded,
+            /// <summary>
+            /// A new rating was recently calculated by the server. Rank may
+            /// not be up to date yet until the next leaderboard upload / download.
+            /// <summary>
+            RatingCalculated,
+        }
+
+        public StateType State { get; init; }
+
         /// <summary> The score that defines where in the ranking the player is. </summary>
-        /// <remarks>0 means that the user has no score yet</remarks>
-        public int Rating;
+        public int Rating { get; init; }
 
         // https://partner.steamgames.com/doc/api/ISteamUserStats#LeaderboardScoreUploaded_t
         /// <summary>Up to date rank is obtained from Steam when leaderboard entries are downloaded. </summary>
-        /// <remarks>0 means that the user has no global leaderboard entry yet.</remarks>        
-        public int Rank;
+        public int Rank { get; init; }
 
         /// <summary>
         /// Time when the rating score was awarded. Stored in the Steam leaderboard "UGC" extra data.
         /// Also used to track when the score needs to be uploaded to the Steam leaderboard 
         /// by the local player client.
         /// </summary>
-        public DateTime RatingAwardedTime { get; set; }
+        public DateTime RatingAwardedTime { get; init; }
+
+        /// <summary>
+        /// Time when the Rank was downloaded from Steam. Used to ensure that newer rank
+        /// information obtained by the client for its own user is not overwritten with
+        /// older data from the server.
+        /// </summary>
+        public DateTime RankDownloadedTime { get; init; }
+
+        public bool UpToDate { get; init; }
+
+        public PilotRanking WithUpToDate(bool upToDate) =>
+            new PilotRanking() { State = State, Rank = Rank, RankDownloadedTime = RankDownloadedTime, Rating = Rating, RatingAwardedTime = RatingAwardedTime, UpToDate = upToDate };
 
         static public PilotRanking FromLeaderboardEntry(LeaderboardEntryAndUgc entryAndUgc)
         {
@@ -29,23 +71,14 @@ namespace AW2.Stats
             {
                 awardedTime = new DateTime(((long)entryAndUgc.ugc[0] << 32) | (uint)entryAndUgc.ugc[1]);
             }
+
             return new PilotRanking
             {
+                State = StateType.RankingDownloaded,
                 Rating = entryAndUgc.entry.m_nScore,
                 Rank = entryAndUgc.entry.m_nGlobalRank,
                 RatingAwardedTime = awardedTime,
-            };
-        }
-
-        public PilotRanking UpdateRating(int rating, DateTime now)
-        {
-            if (rating == Rating) return this;
-            return new PilotRanking
-            {
-                Rating = rating,
-                // note that the rank is not accurate at this point, but it is still better than nothing.
-                Rank = Rank,
-                RatingAwardedTime = now,
+                RankDownloadedTime = DateTime.Now,
             };
         }
 
@@ -57,37 +90,64 @@ namespace AW2.Stats
             }
         }
 
-        private static readonly DateTime AwardedTimeSanityCheckLow = DateTime.Parse("2023-07-01T00:00:00Z");
+        private static readonly DateTime TimeSanityCheckLow = DateTime.Parse("2023-07-01T00:00:00Z");
 
-        public bool IsValid { get { return Rating > 0 && RatingAwardedTime > AwardedTimeSanityCheckLow; } }
-
-        public string RankString
+        public bool IsStateValid
         {
             get
             {
-                if (IsRankValid)
+                return State switch
                 {
-                    return Rank.ToOrdinalString();
-                }
-                else
-                {
-                    return "n/a";
-                }
+                    StateType.DownloadFailed or
+                    StateType.NotRatedYet or
+                    StateType.RankingDownloaded or
+                    StateType.RatingCalculated
+                      => true,
+                    _ => false,
+                };
             }
+        }
+
+        public bool IsValid
+        {
+            get
+            {
+                return IsStateValid &&
+                    Rating >= 0 &&
+                    RatingAwardedTime >= TimeSanityCheckLow &&
+                    ((Rank == 0 && RankDownloadedTime == DateTime.MinValue) ||
+                     (Rank > 0 && RankDownloadedTime >= TimeSanityCheckLow));
+            }
+        }
+
+        public string RankString
+        {
+            get => IsRankValid ? Rank.ToOrdinalString() : "n/a";
+        }
+
+        public string RatingString
+        {
+            get => IsValid ? Rating.ToString() : "n/a";
         }
 
         public bool IsRankValid => IsValid && Rank > 0; // Default value of 0 before we have downloaded a value back from the Steam leaderboard.
 
         public override string ToString()
         {
-            var playerRating = string.Format(CultureInfo.InvariantCulture, "rating {0}", Rating.ToString());
-            var awardedTime = RatingAwardedTime.ToString("s", DateTimeFormatInfo.InvariantInfo);
-            return $"rank:{RankString} rating:{playerRating} awarded:{awardedTime}";
+            var rating = IsValid ? Rating + "/" + RatingAwardedTime.ToString("s", DateTimeFormatInfo.InvariantInfo) : "n/a";
+            var rank = IsRankValid ? RankString + "/" + RankDownloadedTime.ToString("s", DateTimeFormatInfo.InvariantInfo) : "n/a";
+            return $"[{State} rank:{rank} rating:{rating} UpToDate:{UpToDate}]";
         }
 
         public bool Equals(PilotRanking other)
         {
-            return Rating == other.Rating && Rank == other.Rank && RatingAwardedTime == other.RatingAwardedTime;
+            return
+            State == other.State &&
+            Rating == other.Rating &&
+            Rank == other.Rank &&
+            RatingAwardedTime == other.RatingAwardedTime &&
+            RankDownloadedTime == other.RankDownloadedTime &&
+            UpToDate == other.UpToDate;
         }
 
         public static bool operator ==(PilotRanking left, PilotRanking right)
@@ -107,10 +167,72 @@ namespace AW2.Stats
 
         public override int GetHashCode()
         {
-            var hashCode = Rating;
+            var hashCode = (int)State;
             hashCode = (hashCode * 397) ^ Rank;
+            hashCode = (hashCode * 397) ^ Rating;
+            hashCode = (hashCode * 397) ^ RankDownloadedTime.GetHashCode();
             hashCode = (hashCode * 397) ^ RatingAwardedTime.GetHashCode();
+            hashCode = (hashCode * 397) ^ UpToDate.GetHashCode();
             return hashCode;
+        }
+
+        /// <summary>
+        /// A method that is used by the syncing protocol that uses the Server to calculate
+        /// new ratings for all clients based on previous ratings they have downloaded for
+        /// them selves from steam, and then distributes updated ratings for all clients.
+        /// 
+        /// This method is used when moving data around to ensure each part ends up with
+        /// the latest possible rating and ranking data.
+        /// </summary>
+        public readonly PilotRanking Merge(PilotRanking possiblyNew)
+        {
+            var state = State;
+            var rank = Rank;
+            var rankDownloadedTime = RankDownloadedTime;
+            var rating = Rating;
+            var ratingAwardedTime = RatingAwardedTime;
+
+            if (possiblyNew.State == StateType.RankingDownloaded ||
+                 possiblyNew.State == StateType.RatingCalculated)
+            {
+                // Accept new rank / rating only if it is recently calculated by server or downloaded from Steam.
+
+                if (possiblyNew.IsRankValid &&
+                    RankDownloadedTime < possiblyNew.RankDownloadedTime)
+                {
+                    state = possiblyNew.State;
+                    rank = possiblyNew.Rank; // We have no Rank and the other one has, so we take it.
+                    rankDownloadedTime = possiblyNew.RankDownloadedTime;
+                }
+
+                if (possiblyNew.IsValid &&
+                    RatingAwardedTime < possiblyNew.RatingAwardedTime)
+                {
+                    state = possiblyNew.State;
+                    ratingAwardedTime = possiblyNew.RatingAwardedTime;
+                    rating = possiblyNew.Rating;
+                }
+            }
+            else
+            {
+                // Record the most interesting state
+                if (possiblyNew.State > State)
+                {
+                    state = possiblyNew.State;
+                }
+            }
+
+            var result = new PilotRanking
+            {
+                State = state,
+                Rank = rank,
+                RankDownloadedTime = rankDownloadedTime,
+                Rating = rating,
+                RatingAwardedTime = ratingAwardedTime,
+                UpToDate = UpToDate,
+            };
+
+            return result.WithUpToDate(result == this && UpToDate);
         }
     }
 }

--- a/AssaultWingCore/UI/DedicatedServerLogic.cs
+++ b/AssaultWingCore/UI/DedicatedServerLogic.cs
@@ -47,7 +47,7 @@ namespace AW2.UI
         {
             Game.DataEngine.UpdateStandings();
             var finalStandings = Game.DataEngine.Standings;
-            Game.Components.OfType<PilotRatingsUpdater>()?.First()?.EndArena(finalStandings);
+            Game.Components.OfType<PilotRatingsUpdater>()?.FirstOrDefault()?.EndArena(finalStandings);
             Game.DataEngine.ClearGameState();
             GameState = GAMESTATE_INITIALIZING;
         }

--- a/AssaultWingCore/UI/DedicatedServerLogic.cs
+++ b/AssaultWingCore/UI/DedicatedServerLogic.cs
@@ -40,14 +40,17 @@ namespace AW2.UI
             Game.StartArenaBase();
             GameState = GAMESTATE_GAMEPLAY;
             SteamServerComponent.SendUpdatedServerDetailsToSteam();
-            Game.Components.OfType<PilotRatingsUpdater>()?.First()?.StartArena();
         }
 
         public override void FinishArena()
         {
             Game.DataEngine.UpdateStandings();
             var finalStandings = Game.DataEngine.Standings;
+
+            // Update pilot ratings and send updates to clients
             Game.Components.OfType<PilotRatingsUpdater>()?.FirstOrDefault()?.EndArena(finalStandings);
+            Game.SendPilotRankingsToClientsOnServer();
+
             Game.DataEngine.ClearGameState();
             GameState = GAMESTATE_INITIALIZING;
         }

--- a/devdocs/steam-deploy.md
+++ b/devdocs/steam-deploy.md
@@ -1,5 +1,9 @@
 # The Steam deployment of Assault Wing
 
+The version number comes from tag. To tag a version do: ```
+git tag v1.27.0.0
+```
+
 There are 2 scripts to work with Steam builds:
 - The `scripts/build.sh` sets up builds for local development of the Steam features.
 - The `scripts/steam_build.sh` builds and uploads official builds to Steam.


### PR DESCRIPTION
The API for querying leaderboard does not work without a logged in user. When running DedicatedServer with Steam command line client, it does not appear to be possible to be similarly logged in. The command line client is only meant for updating and downloading the server.

Getting the leaderboard to work from pure server side would require setting up publisher keys and using the Web API, which
seems to be too much work to start from scratch right now.

To overcome this limitation and have ranking work with any type of server, this PR implements a P2P style of data fetching/updating from Steam. This way the server relies completely on clients to provide the data and do the updates and server does not need access to the leaderboard directly.